### PR TITLE
configurable raygun user tracking

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -38,6 +38,9 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('async')
                     ->defaultTrue()
                 ->end() // async
+                ->booleanNode('track_users')
+                    ->defaultTrue()
+                ->end() // track_users
                 ->booleanNode('debug_mode')
                     ->defaultFalse()
                 ->end() // debug_mode

--- a/DependencyInjection/NietonfirRaygunExtension.php
+++ b/DependencyInjection/NietonfirRaygunExtension.php
@@ -35,6 +35,7 @@ class NietonfirRaygunExtension extends Extension
         $container->setParameter('nietonfir_raygun.api_key', $config['api_key']);
         $container->setParameter('nietonfir_raygun.async', $config['async']);
         $container->setParameter('nietonfir_raygun.debug_mode', $config['debug_mode']);
+        $container->setParameter('nietonfir_raygun.disable_user_tracking', !$config['track_users']);
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -20,7 +20,7 @@
             <argument>%nietonfir_raygun.api_key%</argument>
             <argument>%nietonfir_raygun.async%</argument>
             <argument>%nietonfir_raygun.debug_mode%</argument>
-            <argument>%nietonfir_raygun.track_users%</argument>
+            <argument>%nietonfir_raygun.disable_user_tracking%</argument>
         </service>
 
         <service id="nietonfir_raygun.monolog_handler" class="%nietonfir_raygun.monolog_handler.class%" public="false">

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -20,6 +20,7 @@
             <argument>%nietonfir_raygun.api_key%</argument>
             <argument>%nietonfir_raygun.async%</argument>
             <argument>%nietonfir_raygun.debug_mode%</argument>
+            <argument>%nietonfir_raygun.track_users%</argument>
         </service>
 
         <service id="nietonfir_raygun.monolog_handler" class="%nietonfir_raygun.monolog_handler.class%" public="false">

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -30,9 +30,11 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('api_key', $config);
         $this->assertArrayHasKey('async', $config);
         $this->assertArrayHasKey('debug_mode', $config);
+        $this->assertArrayHasKey('track_users', $config);
         $this->assertEquals($key, $config['api_key']);
         $this->assertTrue($config['async']);
         $this->assertFalse($config['debug_mode']);
+        $this->assertTrue($config['track_users']);
     }
 
     public function testDebugModeSet()
@@ -53,6 +55,22 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($config['debug_mode']);
     }
 
+    public function testDisableUserTracking()
+    {
+    	$key = '1234567';
+    
+    	$configs = array(
+    			array(
+    					'api_key' => $key,
+    					'track_users' => false
+    			)
+    	);
+    	$config = $this->process($configs);
+    
+    	$this->assertArrayHasKey('track_users', $config);
+    	$this->assertFalse($config['track_users']);
+    }
+        
     /**
      * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      */

--- a/Tests/DependencyInjection/NietonfirRaygunExtensionTest.php
+++ b/Tests/DependencyInjection/NietonfirRaygunExtensionTest.php
@@ -33,6 +33,7 @@ class NietonfirRaygunExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertParameter('1234567', 'nietonfir_raygun.api_key');
         $this->assertParameter(true, 'nietonfir_raygun.async');
         $this->assertParameter(false, 'nietonfir_raygun.debug_mode');
+        $this->assertParameter(false, 'nietonfir_raygun.disable_user_tracking');
         $this->assertHasDefinition('nietonfir_raygun.monolog_handler');
         $this->assertHasDefinition('nietonfir_raygun.twig_extension');
     }
@@ -49,6 +50,7 @@ class NietonfirRaygunExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertParameter('987655', 'nietonfir_raygun.api_key');
         $this->assertParameter(false, 'nietonfir_raygun.async');
         $this->assertParameter(true, 'nietonfir_raygun.debug_mode');
+        $this->assertParameter(true, 'nietonfir_raygun.disable_user_tracking');
         $this->assertHasDefinition('nietonfir_raygun.monolog_handler');
         $this->assertHasDefinition('nietonfir_raygun.twig_extension');
     }
@@ -78,6 +80,7 @@ EOF;
 api_key: 987655
 async: false
 debug_mode: true
+track_users: false
 EOF;
         $parser = new Parser();
         return $parser->parse($yaml);


### PR DESCRIPTION
This adds a new track_users config property to enable or disable raygun4php's user tracking. It defaults to true and thus does not change any previous behavior. 

The parameter in raygun4php is a double negative ($disableUserTracking = false) which is bad style, so I've reversed that logic (i.e. the config is called track_users which gets turned into the inverse nietonfir_raygun.disable_user_tracking). It's still somewhat ugly but more user friendly than raygun4php's approach. 
