### PR TITLE
Feature ignore 404

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -41,6 +41,9 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('debug_mode')
                     ->defaultFalse()
                 ->end() // debug_mode
+                ->booleanNode('ignore_404')
+                    ->defaultFalse()
+                ->end() // ignore_404
             ->end()
             ->validate()
                 ->ifTrue(function($v){return $v['debug_mode'];})

--- a/DependencyInjection/NietonfirRaygunExtension.php
+++ b/DependencyInjection/NietonfirRaygunExtension.php
@@ -38,5 +38,15 @@ class NietonfirRaygunExtension extends Extension
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
+
+        $this->configureHandler($config, $container);
+    }
+
+    protected function configureHandler(array $config, ContainerBuilder $container)
+    {
+        if ($config['ignore_404']) {
+            $handlerDefinition = $container->getDefinition('nietonfir_raygun.monolog_handler');
+            $handlerDefinition->addMethodCall('setIgnore404', [true]);
+        }
     }
 }

--- a/DependencyInjection/NietonfirRaygunExtension.php
+++ b/DependencyInjection/NietonfirRaygunExtension.php
@@ -46,7 +46,7 @@ class NietonfirRaygunExtension extends Extension
     {
         if ($config['ignore_404']) {
             $handlerDefinition = $container->getDefinition('nietonfir_raygun.monolog_handler');
-            $handlerDefinition->addMethodCall('setIgnore404', [true]);
+            $handlerDefinition->addMethodCall('setIgnore404', array(true));
         }
     }
 }

--- a/Monolog/Handler/RaygunHandler.php
+++ b/Monolog/Handler/RaygunHandler.php
@@ -21,6 +21,11 @@ class RaygunHandler extends AbstractProcessingHandler
     protected $client;
 
     /**
+     * @var bool
+     */
+    private $ignore404 = false;
+
+    /**
      * @param RaygunClient $client The Raygun.io client responsible for sending errors/exceptions to Raygun
      * @param int          $level  The minimum logging level at which this handler will be triggered
      * @param Boolean      $bubble Whether the messages that are handled can bubble up the stack or not
@@ -30,6 +35,22 @@ class RaygunHandler extends AbstractProcessingHandler
         $this->client = $client;
 
         parent::__construct($level, $bubble);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isIgnore404()
+    {
+        return $this->ignore404;
+    }
+
+    /**
+     * @param bool $ignore404
+     */
+    public function setIgnore404($ignore404)
+    {
+        $this->ignore404 = (bool)$ignore404;
     }
 
     /**

--- a/Monolog/Handler/RaygunHandler.php
+++ b/Monolog/Handler/RaygunHandler.php
@@ -15,6 +15,7 @@ use Monolog\Formatter\NormalizerFormatter;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Logger;
 use Raygun4php\RaygunClient;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class RaygunHandler extends AbstractProcessingHandler
 {
@@ -62,6 +63,10 @@ class RaygunHandler extends AbstractProcessingHandler
         $exception = isset($ctx['exception']) ? $ctx['exception'] : false;
 
         if ($exception) {
+            if ($this->ignore404 && $exception instanceof NotFoundHttpException) {
+                return;
+            }
+
             $this->client->sendException($exception);
         } else {
             $this->client->sendError($record['level'], $record['message'], $ctx['file'], $ctx['line']);

--- a/README.md
+++ b/README.md
@@ -83,3 +83,15 @@ Raygun pulse can be enabled by either setting or passing a truthy variable named
 ```twig
 {% include 'NietonfirRaygunBundle::setup.html.twig' with {'enable_pulse': true} only %}
 ```
+
+Configuration Reference
+-----------------------
+
+```yaml
+# app/config/config.yml
+nietonfir_raygun:
+    api_key: %raygun_api_key% # Your Raygun API key, available under "Application Settings" in your Raygun account.
+    async: true               # Sets the [async configuration option](https://github.com/MindscapeHQ/raygun4php#sending-method---asyncsync) on the Raygun client.
+    debug_mode: false         # Sets the [debug configuration option](https://github.com/MindscapeHQ/raygun4php#debug-mode) on the Raygun client.
+    ignore_404: false         # Whether to send 404 exceptions (NotFoundHttpException) to Raygun
+```

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -30,9 +30,11 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('api_key', $config);
         $this->assertArrayHasKey('async', $config);
         $this->assertArrayHasKey('debug_mode', $config);
+        $this->assertArrayHasKey('ignore_404', $config);
         $this->assertEquals($key, $config['api_key']);
         $this->assertTrue($config['async']);
         $this->assertFalse($config['debug_mode']);
+        $this->assertFalse($config['ignore_404']);
     }
 
     public function testDebugModeSet()
@@ -51,6 +53,22 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('debug_mode', $config);
         $this->assertFalse($config['async']);
         $this->assertTrue($config['debug_mode']);
+    }
+
+    public function testIgnore404ModeSet()
+    {
+        $key = '1234567';
+
+        $configs = array(
+            array(
+                'api_key' => $key,
+                'ignore_404' => true
+            )
+        );
+        $config = $this->process($configs);
+
+        $this->assertArrayHasKey('ignore_404', $config);
+        $this->assertTrue($config['ignore_404']);
     }
 
     /**

--- a/Tests/DependencyInjection/NietonfirRaygunExtensionTest.php
+++ b/Tests/DependencyInjection/NietonfirRaygunExtensionTest.php
@@ -51,6 +51,7 @@ class NietonfirRaygunExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertParameter(true, 'nietonfir_raygun.debug_mode');
         $this->assertHasDefinition('nietonfir_raygun.monolog_handler');
         $this->assertHasDefinition('nietonfir_raygun.twig_extension');
+        $this->assertHasCall('nietonfir_raygun.monolog_handler', 'setIgnore404');
     }
 
     /**
@@ -78,6 +79,7 @@ EOF;
 api_key: 987655
 async: false
 debug_mode: true
+ignore_404: true
 EOF;
         $parser = new Parser();
         return $parser->parse($yaml);
@@ -107,6 +109,12 @@ EOF;
     private function assertHasDefinition($id)
     {
         $this->assertTrue(($this->configuration->hasDefinition($id) ?: $this->configuration->hasAlias($id)));
+    }
+
+    private function assertHasCall($id, $method)
+    {
+        $definition = $this->configuration->getDefinition($id);
+        $this->assertTrue($definition->hasMethodCall($method));
     }
 
     protected function tearDown()

--- a/Tests/Monolog/Handler/RaygunHandlerTest.php
+++ b/Tests/Monolog/Handler/RaygunHandlerTest.php
@@ -65,4 +65,18 @@ class RaygunHandlerTest extends TestCase
         $handler = new RaygunHandler($this->client);
         $handler->handle($record);
     }
+
+    public function testIgnore404()
+    {
+        $exceptionMock = $this->getMock('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+
+        $record = $this->getRecord(Logger::CRITICAL, 'test', array('exception' => $exceptionMock));
+
+        $this->client->expects($this->never())
+            ->method('sendException');
+
+        $handler = new RaygunHandler($this->client);
+        $handler->setIgnore404(true);
+        $handler->handle($record);
+    }
 }


### PR DESCRIPTION
This branch adds a configuration option to the `RaygunHandler` that disables the delivery of `NotFoundHttpException`s to Raygun.

I've found that delivering errors about missing favicon.ico files and other hacking attempts to Raygun creates a lot of noise in the dashboard. This branch allows you to remove 404 errors from logging.

By default it is disabled, so will not break compatibility with existing installations. Can be configured by adding the `ignore_404: true` option to the `nietonfir_raygun` configuration option.
